### PR TITLE
Fix show prop on Dropdown component

### DIFF
--- a/components/Dropdown.jsx
+++ b/components/Dropdown.jsx
@@ -8,7 +8,7 @@ import DropdownContent from './DropdownContent.js';
 var Dropdown = createClass({
   getInitialState: function(){
     return {
-      active: false
+      active: this.props.show || false
     };
   },
   getDefaultProps: function(){

--- a/components/Dropdown.jsx
+++ b/components/Dropdown.jsx
@@ -16,6 +16,11 @@ var Dropdown = createClass({
       className: ''
     }
   },
+  componentWillReceiveProps: function(nextProps) {
+    if (this.props.show) {
+      this.setState({ active: true});
+    }
+  },
   componentDidMount: function () {
     window.addEventListener( 'click', this._onWindowClick );
   },


### PR DESCRIPTION
In the npm docs, it says that if you pass the show prop to the dropdown, you can force it to start in an open state. This appears to be missing and is a simple fix.
