### PR TITLE
Update react and related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "dom-classes": "0.0.1",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^1.4.0",
-    "react": "15.0.x",
-    "react-addons-test-utils": "15.0.x",
-    "react-dom": "15.0.x",
+    "react": "^15.0.0",
+    "react-addons-test-utils": "^15.0.0",
+    "react-dom": "^15.0.0",
     "simple-mock": "^0.3.1",
     "tape": "^4.0.0",
     "trash-cli": "^1.2.0",
@@ -55,8 +55,8 @@
     "zuul": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "0.14.x || 15.0.x",
-    "react-dom": "0.14.x || 15.0.x"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Use major version lock instead of minor.
Fix #13.