### PR TITLE
Added new prop to customise css class

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ Property | Type | Description
 **show** | *boolean* | Manually show/hide the `DropdownContent`. Make sure to unset this or the dropdown will stay open.
 **onShow** | *function* | Callback for when `DropdownContent` is shown.
 **onHide** | *function* | Callback for when `DropdownContent` is hidden.
+**activeClassName** | *string* | Class to be applied to the dropdown when active. Default value: 'dropdown--active'

--- a/components/Dropdown.jsx
+++ b/components/Dropdown.jsx
@@ -16,7 +16,8 @@ var Dropdown = createClass({
 
   getDefaultProps () {
     return {
-      className: ''
+      className: '',
+      activeClassName: 'dropdown--active'
     }
   },
 
@@ -34,7 +35,7 @@ var Dropdown = createClass({
     const active = this.isActive();
     var dropdown_classes = cx({
       dropdown: true,
-      'dropdown--active': active
+      [activeClassName]: active
     });
     dropdown_classes += ' ' + className;
     // stick callback on trigger element

--- a/components/Dropdown.jsx
+++ b/components/Dropdown.jsx
@@ -30,7 +30,7 @@ var Dropdown = createClass({
   },
 
   render () {
-    const { children, className } = this.props;
+    const { children, className, activeClassName } = this.props;
     // create component classes
     const active = this.isActive();
     var dropdown_classes = cx({


### PR DESCRIPTION
First of all, thanks for taking the time to share this package!

This is a very simple addition, in order to allow customisation of active state class.

My use case for this addition is to be able to use existing css (bootstrap lib for instance), instead os adding Dropdown.css, taking advantage of js functionality and nothing else. All elements already accept additional classes via `className`, so this was the only thing preventing a full customisation.

I have also updated the readme file for clarity.
Thanks