### PR TITLE
Close dropdown menu by tapping on mobile

### DIFF
--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -22,10 +22,12 @@ var Dropdown = createClass({
 
   componentDidMount () {
     window.addEventListener( 'click', this._onWindowClick );
+    window.addEventListener( 'touchstart', this._onWindowClick );
   },
 
   componentWillUnmount () {
     window.removeEventListener( 'click', this._onWindowClick );
+    window.removeEventListener( 'touchstart', this._onWindowClick );
   },
 
   render () {


### PR DESCRIPTION
To make a dropdown menu closed by tapping on a mobile device. (I've checked with iOS.)