### PR TITLE
Pass event object to onShow and onHide handlers

### DIFF
--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -64,21 +64,21 @@ var Dropdown = createClass({
       this.state.active;
   },
 
-  hide () {
+  hide ( event ) {
     this.setState({
       active: false
     });
     if( this.props.onHide ){
-      this.props.onHide();
+      this.props.onHide( event );
     }
   },
 
-  show () {
+  show ( event ) {
     this.setState({
       active: true
     });
     if( this.props.onShow ){
-      this.props.onShow();
+      this.props.onShow( event );
     }
   },
 
@@ -92,9 +92,9 @@ var Dropdown = createClass({
   _onToggleClick ( event ) {
     event.preventDefault();
     if( this.isActive() ){
-      this.hide();
+      this.hide( event );
     } else {
-      this.show();
+      this.show( event );
     }
   }
 });


### PR DESCRIPTION
I'd like to pass the event object to the handlers because I want to call stopPropagation because my dropdown is in a component that has its own click handler that I want to avoid triggering.