### PR TITLE
Remove href from DropdownTrigger

### DIFF
--- a/src/components/DropdownTrigger.jsx
+++ b/src/components/DropdownTrigger.jsx
@@ -22,7 +22,7 @@ const DropdownTrigger = createClass({
     };
 
     return (
-      <a {...props} href="#dropdown-trigger">
+      <a {...props}>
         {children}
       </a>
     );


### PR DESCRIPTION
Removes the href attribute from the DropdownTrigger component. Couldn't think of a good reason for its presence. 
Fixes https://github.com/Fauntleroy/react-simple-dropdown/issues/29. 