### PR TITLE
Support for custom activeClassName & tagName

### DIFF
--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -78,12 +78,13 @@ class Dropdown extends Component {
       onHide,
       className,
       component = 'div',
-      activeClassName = 'dropdown--active',
       ...otherProps
     } = this.props;
     const Component = component;
     // create component classes
     const isActive = this.isActive();
+    const activeClassName = Dropdown.customClasses.active
+
     const dropdownClasses = cx({
       dropdown: true,
       [activeClassName]: isActive
@@ -113,6 +114,10 @@ class Dropdown extends Component {
       </Component>
     );
   }
+}
+
+Dropdown.customClasses = {
+  active: 'dropdown--active'
 }
 
 Dropdown.propTypes = {

--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -77,7 +77,7 @@ class Dropdown extends Component {
       onShow,
       onHide,
       className,
-      component = 'div',
+      component,
       ...otherProps
     } = this.props;
     const Component = component;
@@ -130,7 +130,8 @@ Dropdown.propTypes = {
 };
 
 Dropdown.defaultProps = {
-  className: ''
+  className: '',
+  component: 'div'
 };
 
 export { DropdownTrigger, DropdownContent };

--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -71,12 +71,22 @@ class Dropdown extends Component {
   }
 
   render () {
-    const { children, className } = this.props;
+    const {
+      children,
+      active,
+      onShow,
+      onHide,
+      className,
+      component = 'div',
+      activeClassName = 'dropdown--active',
+      ...otherProps
+    } = this.props;
+    const Component = component;
     // create component classes
-    const active = this.isActive();
+    const isActive = this.isActive();
     const dropdownClasses = cx({
       dropdown: true,
-      'dropdown--active': active
+      [activeClassName]: isActive
     });
     // stick callback on trigger element
     const boundChildren = React.Children.map(children, child => {
@@ -94,17 +104,13 @@ class Dropdown extends Component {
       }
       return child;
     });
-    const cleanProps = { ...this.props };
-    delete cleanProps.active;
-    delete cleanProps.onShow;
-    delete cleanProps.onHide;
 
     return (
-      <div
-        {...cleanProps}
+      <Component
+        {...otherProps}
         className={`${dropdownClasses} ${className}`}>
         {boundChildren}
-      </div>
+      </Component>
     );
   }
 }

--- a/src/components/DropdownContent.jsx
+++ b/src/components/DropdownContent.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 class DropdownContent extends Component {
   render () {
-    const { children, className, component='div', ...dropdownContentProps } = this.props;
+    const { children, className, component, ...dropdownContentProps } = this.props;
     const Component = component
     dropdownContentProps.className = `dropdown__content ${className}`;
 
@@ -23,7 +23,8 @@ DropdownContent.propTypes = {
 };
 
 DropdownContent.defaultProps = {
-  className: ''
+  className: '',
+  component: 'div'
 };
 
 export default DropdownContent;

--- a/src/components/DropdownContent.jsx
+++ b/src/components/DropdownContent.jsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 
 class DropdownContent extends Component {
   render () {
-    const { children, className, ...dropdownContentProps } = this.props;
+    const { children, className, component='div', ...dropdownContentProps } = this.props;
+    const Component = component
     dropdownContentProps.className = `dropdown__content ${className}`;
 
     return (
-      <div {...dropdownContentProps}>
+      <Component {...dropdownContentProps}>
         {children}
-      </div>
+      </Component>
     );
   }
 }

--- a/src/components/DropdownTrigger.jsx
+++ b/src/components/DropdownTrigger.jsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 
 class DropdownTrigger extends Component {
   render () {
-    const { children, className, ...dropdownTriggerProps } = this.props;
+    const { children, className, component = 'a', ...dropdownTriggerProps } = this.props;
+    const Component = component;
     dropdownTriggerProps.className = `dropdown__trigger ${className}`;
 
     return (
-      <a {...dropdownTriggerProps}>
+      <Component {...dropdownTriggerProps}>
         {children}
-      </a>
+      </Component>
     );
   }
 }

--- a/src/components/DropdownTrigger.jsx
+++ b/src/components/DropdownTrigger.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 class DropdownTrigger extends Component {
   render () {
-    const { children, className, component = 'a', ...dropdownTriggerProps } = this.props;
+    const { children, className, component, ...dropdownTriggerProps } = this.props;
     const Component = component;
     dropdownTriggerProps.className = `dropdown__trigger ${className}`;
 
@@ -23,7 +23,8 @@ DropdownTrigger.propTypes = {
 };
 
 DropdownTrigger.defaultProps = {
-  className: ''
+  className: '',
+  component: 'a'
 };
 
 export default DropdownTrigger;


### PR DESCRIPTION
This PR allows you to specify custom active class name & tag name for the dropdown components. This customization will allow to reuse the components seamlessly with UI frameworks like bootstrap without need of any custom css. Something like

```jsx
<Dropdown component="li" activeClassName="open">
  <DropdownTrigger class="dropdown-toggle">
    {modeFormatted} <span class="caret" />
  </DropdownTrigger>
  <DropdownContent component="ul" class="dropdown-menu">
    <li><a>Test Mode</a></li>
    <li><a>Live Mode</a></li>
  </DropdownContent>
</Dropdown>
```

**Before - Rendered DOM**
```html
<li>
    <div class="dropdown dropdown--active ">
        <a class="dropdown__trigger dropdown-toggle">
            <!-- react-text: 11 -->Test
            <!-- /react-text -->
            <!-- react-text: 12 -->
            <!-- /react-text --><span class="caret"></span></a>
        <div class="dropdown__content dropdown-menu">
            <ul>
                <li><a>Test Mode</a></li>
                <li><a>Live Mode</a></li>
            </ul>
        </div>
    </div>
</li>
```

**After - Rendered DOM**
```html
<li class="dropdown open">
    <a data-toggle="dropdown" class="dropdown__trigger dropdown-toggle">
        <!-- react-text: 11 -->Test
        <!-- /react-text -->
        <!-- react-text: 12 -->
        <!-- /react-text --><span class="caret"></span></a>
    <ul class="dropdown__content dropdown-menu">
        <li><a>Test Mode</a></li>
        <li><a>Live Mode</a></li>
    </ul>
</li>
```
