### PR TITLE
add default tabIndex to DropdownTrigger

### DIFF
--- a/src/components/DropdownTrigger.jsx
+++ b/src/components/DropdownTrigger.jsx
@@ -7,7 +7,7 @@ class DropdownTrigger extends Component {
     dropdownTriggerProps.className = `dropdown__trigger ${className}`;
 
     return (
-      <a {...dropdownTriggerProps}>
+      <a tabIndex="0" {...dropdownTriggerProps}>
         {children}
       </a>
     );


### PR DESCRIPTION
Closes #44.

[Taken from WebAIM](https://webaim.org/techniques/keyboard/tabindex):
>tabindex="0" allows elements besides links and form elements to receive keyboard focus. It does not change the tab order, but places the element in the logical navigation flow, as if it were a link on the page.