### PR TITLE
add check for prototype instanceof in case === fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-dropdown",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Non-prescriptive React.js dropdown toolkit",
   "main": "lib/components/Dropdown.js",
   "scripts": {
@@ -78,7 +78,7 @@
     "zuul": "^3.11.1"
   },
   "peerDependencies": {
-    "react": "0.14.x || 15.x",
-    "react-dom": "0.14.x || 15.x"
+    "react": "0.14.x || 15.x || 16.x",
+    "react-dom": "0.14.x || 15.x || 16.x"
   }
 }

--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -83,7 +83,7 @@ class Dropdown extends Component {
     });
     // stick callback on trigger element
     const boundChildren = React.Children.map(children, child => {
-      if (child.type === DropdownTrigger) {
+      if (child.type === DropdownTrigger || child.type.prototype instanceof DropdownTrigger) {
         const originalOnClick = child.props.onClick;
         child = cloneElement(child, {
           ref: 'trigger',
@@ -96,7 +96,7 @@ class Dropdown extends Component {
             }
           }
         });
-      } else if (child.type === DropdownContent && removeElement && !active) {
+      } else if ((child.type === DropdownContent || child.type.prototype instanceof DropdownContent) && removeElement && !active) {
         child = null;
       }
       return child;


### PR DESCRIPTION
I'm using this component in with react ^16.3.1 and it works fine. However, when I embed it in an app that uses next.js, the equality check on the children fails. In this case, we should check to see if it's an instanceof.