### PR TITLE
Use button element for DropdownTrigger

### DIFF
--- a/src/components/dropdown-trigger.jsx
+++ b/src/components/dropdown-trigger.jsx
@@ -7,9 +7,9 @@ class DropdownTrigger extends Component {
     dropdownTriggerProps.className = `dropdown__trigger ${className}`;
 
     return (
-      <a {...dropdownTriggerProps}>
+      <button {...dropdownTriggerProps}>
         {children}
-      </a>
+      </button>
     );
   }
 }


### PR DESCRIPTION
A few open Issues mention the need for Keyboard accessibility:

- #54 a11y: onEnter keydown on DropdownTrigger
- #44 a11y: Can't tab into DropdownTrigger

Full keyboard support is a much larger task. Still, simply changing the DropdownToggle element from a link to a button (`<a>` to `<button>`) is a much needed start in the right direction.